### PR TITLE
👷 ci: deploy api to Azure Container Registry

### DIFF
--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -4,12 +4,10 @@ on:
     push:
       branches:
         - staging
-        - deploy
     pull_request:
       types: [closed]
       branches:
         - staging
-        - deploy
     workflow_dispatch:
 
 jobs:
@@ -40,4 +38,4 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.AZURE_REGISTRY_LOGIN_SERVER }}/fairhub:test
+          tags: ${{ secrets.AZURE_REGISTRY_LOGIN_SERVER }}/fairhub:staging

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -1,0 +1,43 @@
+name: Docker
+
+on:
+    push:
+      branches:
+        - staging
+        - deploy
+    pull_request:
+      types: [closed]
+      branches:
+        - staging
+        - deploy
+    workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and push Docker image
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    env:
+      FAIRHUB_DATABASE_URL: ${{ secrets.FAIRHUB_STAGING_DATABASE_URL }}
+      AZURE_REGISTRY_LOGIN_SERVER: ${{ secrets.AZURE_REGISTRY_LOGIN_SERVER }}
+      AZURE_REGISTRY_USERNAME: ${{ secrets.AZURE_REGISTRY_USERNAME }}
+      AZURE_REGISTRY_PASSWORD: ${{ secrets.AZURE_REGISTRY_PASSWORD }}
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to Azure Container Registry
+        uses: azure/docker-login@v1
+        with:
+          login-server: ${{ secrets.AZURE_REGISTRY_LOGIN_SERVER }}
+          username: ${{ secrets.AZURE_REGISTRY_USERNAME }}
+          password: ${{ secrets.AZURE_REGISTRY_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.AZURE_REGISTRY_LOGIN_SERVER }}/fairhub:test

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: Build and push Docker image to Azure Container Registry (staging)
 
 on:
     push:

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     name: Build and push Docker image
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     env:
       FAIRHUB_DATABASE_URL: ${{ secrets.FAIRHUB_STAGING_DATABASE_URL }}


### PR DESCRIPTION
This is for staging only at the moment but the image is now pushed to ACR. 

Meant for the staging deployment